### PR TITLE
docs: Fix simple typo, specifing -> specifying

### DIFF
--- a/nive_cms/cmsview/static/mods/jquery-ui-1.10.3/js/jquery-1.9.1.js
+++ b/nive_cms/cmsview/static/mods/jquery-ui-1.10.3/js/jquery-1.9.1.js
@@ -6836,7 +6836,7 @@ jQuery.extend({
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 				style[ name ] = "inherit";


### PR DESCRIPTION
There is a small typo in nive_cms/cmsview/static/mods/jquery-ui-1.10.3/js/jquery-1.9.1.js.

Should read `specifying` rather than `specifing`.

